### PR TITLE
Load routes after successful MongoDB connection

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -13,38 +13,39 @@ app.use(cors({
   allowedHeaders: ['Content-Type', 'Authorization']
 }));
 
+// Conexão com o MongoDB
 mongoose.connect(process.env.MONGODB_URI, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
   serverSelectionTimeoutMS: 20000 
 })
-  .then(() => {
-    console.log('Conectado ao MongoDB com sucesso');
-  })
-  .catch((err) => {
-    console.error('Erro ao conectar ao MongoDB:', err);
+.then(() => {
+  console.log('✅ Conectado ao MongoDB com sucesso');
+
+  // Agora sim: carrega as rotas só após conexão
+  const authRoute = require("./routes/userRoute");
+  const productRoute = require("./routes/productRoute");
+  const sellsRoute = require("./routes/sellRoute");
+  const objRoute = require("./routes/objRoute");
+
+  app.use("/api/v1", authRoute);
+  app.use("/api/v1", productRoute);
+  app.use("/api/v1", sellsRoute);
+  app.use("/api/v1", objRoute);
+
+  app.get('/', (req, res) => {
+    res.status(200).json({ message: 'API online!!' });
   });
 
-const authRoute = require("./routes/userRoute");
-const productRoute = require("./routes/productRoute");
-const sellsRoute = require("./routes/sellRoute");
-const objRoute = require("./routes/objRoute");
+  // Se não for serverless, inicia o servidor
+  if (require.main === module) {
+    const PORT = process.env.PORT || 5000;
+    app.listen(PORT, () => {
+      console.log(`🚀 Servidor rodando em http://localhost:${PORT}`);
+    });
+  }
 
-// user route done
-app.use("/api/v1", authRoute);
-app.use("/api/v1", productRoute);
-app.use("/api/v1", sellsRoute);
-app.use("/api/v1", objRoute);
-
-app.get('/', (req, res) => {
-  res.status(200).json({ message: 'API online!!' });
+})
+.catch((err) => {
+  console.error('❌ Erro ao conectar ao MongoDB:', err);
 });
-
-// Exportar app para uso com serverless 
-module.exports = app;
-
-//  iniciar servidor localmente (se não for serverless)
-if (require.main === module) {
-  const PORT = process.env.PORT || 5000;
-  app.listen(PORT, () => {
-    console.log(`🚀 Servidor a correr em http://localhost:${PORT}`);
-  });
-}


### PR DESCRIPTION
Routes and server startup are now initialized only after a successful MongoDB connection. This ensures the app does not handle requests before the database is ready, improving reliability and error handling.